### PR TITLE
Remove dependency on Apache's Commons-Lang

### DIFF
--- a/postman/build.gradle
+++ b/postman/build.gradle
@@ -32,6 +32,5 @@ idea {
 dependencies {
     provided 'com.google.android:android:2.3.1'
     compile 'com.squareup:javawriter:2.5.0'
-    compile 'org.apache.commons:commons-lang3:3.3.2'
 	compile 'com.workday:metajava:1.0'
 }

--- a/postman/src/main/java/com/workday/postman/codegen/BoxableSaveStatementWriter.java
+++ b/postman/src/main/java/com/workday/postman/codegen/BoxableSaveStatementWriter.java
@@ -10,8 +10,6 @@ package com.workday.postman.codegen;
 import com.squareup.javawriter.JavaWriter;
 import com.workday.meta.MetaTypes;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
@@ -52,6 +50,8 @@ class BoxableSaveStatementWriter
     }
 
     private String getSaveType(TypeMirror type) {
-        return StringUtils.capitalize(metaTypes.asPrimitive(type).toString());
+        String typeString = metaTypes.asPrimitive(type).toString();
+        if (typeString == null || typeString.length() == 0) return typeString;
+        else return typeString.substring(0, 1).toUpperCase() + typeString.substring(1);
     }
 }

--- a/postman/src/main/java/com/workday/postman/codegen/BoxableSaveStatementWriter.java
+++ b/postman/src/main/java/com/workday/postman/codegen/BoxableSaveStatementWriter.java
@@ -51,7 +51,6 @@ class BoxableSaveStatementWriter
 
     private String getSaveType(TypeMirror type) {
         String typeString = metaTypes.asPrimitive(type).toString();
-        if (typeString == null || typeString.length() == 0) return typeString;
-        else return typeString.substring(0, 1).toUpperCase() + typeString.substring(1);
+        return typeString.substring(0, 1).toUpperCase() + typeString.substring(1);
     }
 }


### PR DESCRIPTION
Postman includes the "heavy" commons-lang library, yet uses it only in one specific place. This PR removes this dependency by providing a lighter implementation of Apache's StringUtils.capitalize() method, which should suffice for the use case at hand.

This fixes #12.

This is a re-submit of #13 with fixes applied to both my remote branch name and the commit messages.
