### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/demo/src/main/java/com/workday/postman/demo/MySerializable.java
+++ b/demo/src/main/java/com/workday/postman/demo/MySerializable.java
@@ -16,4 +16,5 @@ import java.io.Serializable;
 public class MySerializable implements Serializable {
 
     private static final long serialVersionUID = -2730044070809073605L;
+
 }

--- a/demo/src/test/java/com/workday/postman/demo/ParcelTestUtils.java
+++ b/demo/src/test/java/com/workday/postman/demo/ParcelTestUtils.java
@@ -14,7 +14,7 @@ import org.robolectric.RuntimeEnvironment;
 
 public class ParcelTestUtils {
 
-    public ParcelTestUtils() {
+    private ParcelTestUtils() {
     }
 
     public static <T extends Parcelable> T writeAndReadParcelable(Parcelable in) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
