### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/demo/src/main/java/com/workday/postman/demo/MyChildParcelable.java
+++ b/demo/src/main/java/com/workday/postman/demo/MyChildParcelable.java
@@ -24,15 +24,12 @@ public class MyChildParcelable implements Parcelable {
     public static final Creator<MyChildParcelable> CREATOR =
             Postman.getCreator(MyChildParcelable.class);
 
-    @Override
-    public int describeContents() {
-        return 0;
-    }
+    String aString;
 
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        Postman.writeToParcel(this, dest);
-    }
+    Boolean aBoolean;
+
+    @NotParceled
+    String notParceled;
 
     public MyChildParcelable() {
 
@@ -43,10 +40,14 @@ public class MyChildParcelable implements Parcelable {
         this.aBoolean = aBoolean;
     }
 
-    String aString;
+    @Override
+    public int describeContents() {
+        return 0;
+    }
 
-    Boolean aBoolean;
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        Postman.writeToParcel(this, dest);
+    }
 
-    @NotParceled
-    String notParceled;
 }

--- a/demo/src/main/java/com/workday/postman/demo/MyParcelable.java
+++ b/demo/src/main/java/com/workday/postman/demo/MyParcelable.java
@@ -26,23 +26,6 @@ public class MyParcelable implements Parcelable {
 
     public static final Creator<MyParcelable> CREATOR = Postman.getCreator(MyParcelable.class);
 
-    public MyParcelable() {}
-
-    public MyParcelable(String myString) {
-        this.myString = myString;
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        Postman.writeToParcel(this, dest);
-
-    }
-
     @Parceled
     int myInt;
 
@@ -74,4 +57,21 @@ public class MyParcelable implements Parcelable {
     Set<Integer> myIntegerSet;
 
     BigDecimal notParceled;
+
+    public MyParcelable() {}
+
+    public MyParcelable(String myString) {
+        this.myString = myString;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        Postman.writeToParcel(this, dest);
+
+    }
 }

--- a/demo/src/main/java/com/workday/postman/demo/MyParcelableWithPostCreateAction.java
+++ b/demo/src/main/java/com/workday/postman/demo/MyParcelableWithPostCreateAction.java
@@ -24,6 +24,9 @@ import java.util.Map;
 @Parceled
 public class MyParcelableWithPostCreateAction implements Parcelable {
 
+    public static final Creator<MyParcelableWithPostCreateAction> CREATOR = Postman.getCreator(
+            MyParcelableWithPostCreateAction.class);
+
     MyChildParcelable myChildParcelable;
     ArrayList<MyChildParcelable> myChildren;
     MySerializable mySerializable;
@@ -36,9 +39,6 @@ public class MyParcelableWithPostCreateAction implements Parcelable {
             ((MyChildParcelable) child).aString += " seen";
         }
     }
-
-    public static final Creator<MyParcelableWithPostCreateAction> CREATOR = Postman.getCreator(
-            MyParcelableWithPostCreateAction.class);
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/BigDecimalParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/BigDecimalParcelableAdapter.java
@@ -19,10 +19,6 @@ public class BigDecimalParcelableAdapter implements ParcelableAdapter<BigDecimal
 
     private final BigDecimal value;
 
-    public BigDecimalParcelableAdapter(BigDecimal value) {
-        this.value = value;
-    }
-
     public static final Creator<BigDecimalParcelableAdapter> CREATOR =
             new Creator<BigDecimalParcelableAdapter>() {
 
@@ -37,6 +33,10 @@ public class BigDecimalParcelableAdapter implements ParcelableAdapter<BigDecimal
                     return new BigDecimalParcelableAdapter[size];
                 }
             };
+
+    public BigDecimalParcelableAdapter(BigDecimal value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/BigIntegerParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/BigIntegerParcelableAdapter.java
@@ -19,10 +19,6 @@ public class BigIntegerParcelableAdapter implements ParcelableAdapter<BigInteger
 
     private final BigInteger value;
 
-    public BigIntegerParcelableAdapter(BigInteger value) {
-        this.value = value;
-    }
-
     public static final Creator<BigIntegerParcelableAdapter> CREATOR =
             new Creator<BigIntegerParcelableAdapter>() {
 
@@ -37,6 +33,10 @@ public class BigIntegerParcelableAdapter implements ParcelableAdapter<BigInteger
                     return new BigIntegerParcelableAdapter[size];
                 }
             };
+
+    public BigIntegerParcelableAdapter(BigInteger value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/BooleanParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/BooleanParcelableAdapter.java
@@ -17,10 +17,6 @@ public class BooleanParcelableAdapter implements ParcelableAdapter<Boolean> {
 
     private final Boolean value;
 
-    public BooleanParcelableAdapter(Boolean value) {
-        this.value = value;
-    }
-
     public static final Creator<BooleanParcelableAdapter> CREATOR =
             new Creator<BooleanParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class BooleanParcelableAdapter implements ParcelableAdapter<Boolean> {
                     return new BooleanParcelableAdapter[size];
                 }
             };
+
+    public BooleanParcelableAdapter(Boolean value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/ByteParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/ByteParcelableAdapter.java
@@ -17,10 +17,6 @@ public class ByteParcelableAdapter implements ParcelableAdapter<Byte> {
 
     private final Byte value;
 
-    public ByteParcelableAdapter(Byte value) {
-        this.value = value;
-    }
-
     public static final Creator<ByteParcelableAdapter> CREATOR =
             new Creator<ByteParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class ByteParcelableAdapter implements ParcelableAdapter<Byte> {
                     return new ByteParcelableAdapter[size];
                 }
             };
+
+    public ByteParcelableAdapter(Byte value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/CharParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/CharParcelableAdapter.java
@@ -17,10 +17,6 @@ public class CharParcelableAdapter implements ParcelableAdapter<Character> {
 
     private final Character value;
 
-    public CharParcelableAdapter(Character value) {
-        this.value = value;
-    }
-
     public static final Creator<CharParcelableAdapter> CREATOR =
             new Creator<CharParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class CharParcelableAdapter implements ParcelableAdapter<Character> {
                     return new CharParcelableAdapter[size];
                 }
             };
+
+    public CharParcelableAdapter(Character value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/CharSequenceParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/CharSequenceParcelableAdapter.java
@@ -18,10 +18,6 @@ public class CharSequenceParcelableAdapter implements ParcelableAdapter<CharSequ
 
     private final CharSequence value;
 
-    public CharSequenceParcelableAdapter(CharSequence value) {
-        this.value = value;
-    }
-
     public static final Creator<CharSequenceParcelableAdapter> CREATOR =
             new Creator<CharSequenceParcelableAdapter>() {
 
@@ -38,6 +34,10 @@ public class CharSequenceParcelableAdapter implements ParcelableAdapter<CharSequ
                     return new CharSequenceParcelableAdapter[size];
                 }
             };
+
+    public CharSequenceParcelableAdapter(CharSequence value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/DoubleParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/DoubleParcelableAdapter.java
@@ -17,10 +17,6 @@ public class DoubleParcelableAdapter implements ParcelableAdapter<Double> {
 
     private final Double value;
 
-    public DoubleParcelableAdapter(Double value) {
-        this.value = value;
-    }
-
     public static final Creator<DoubleParcelableAdapter> CREATOR =
             new Creator<DoubleParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class DoubleParcelableAdapter implements ParcelableAdapter<Double> {
                     return new DoubleParcelableAdapter[size];
                 }
             };
+
+    public DoubleParcelableAdapter(Double value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/FloatParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/FloatParcelableAdapter.java
@@ -17,10 +17,6 @@ public class FloatParcelableAdapter implements ParcelableAdapter<Float> {
 
     private final Float value;
 
-    public FloatParcelableAdapter(Float value) {
-        this.value = value;
-    }
-
     public static final Creator<FloatParcelableAdapter> CREATOR =
             new Creator<FloatParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class FloatParcelableAdapter implements ParcelableAdapter<Float> {
                     return new FloatParcelableAdapter[size];
                 }
             };
+
+    public FloatParcelableAdapter(Float value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/IntParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/IntParcelableAdapter.java
@@ -17,10 +17,6 @@ public class IntParcelableAdapter implements ParcelableAdapter<Integer> {
 
     private final Integer value;
 
-    public IntParcelableAdapter(Integer value) {
-        this.value = value;
-    }
-
     public static final Creator<IntParcelableAdapter> CREATOR =
             new Creator<IntParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class IntParcelableAdapter implements ParcelableAdapter<Integer> {
                     return new IntParcelableAdapter[size];
                 }
             };
+
+    public IntParcelableAdapter(Integer value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/LongParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/LongParcelableAdapter.java
@@ -17,10 +17,6 @@ public class LongParcelableAdapter implements ParcelableAdapter<Long> {
 
     private final Long value;
 
-    public LongParcelableAdapter(Long value) {
-        this.value = value;
-    }
-
     public static final Creator<LongParcelableAdapter> CREATOR =
             new Creator<LongParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class LongParcelableAdapter implements ParcelableAdapter<Long> {
                     return new LongParcelableAdapter[size];
                 }
             };
+
+    public LongParcelableAdapter(Long value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/ShortParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/ShortParcelableAdapter.java
@@ -17,10 +17,6 @@ public class ShortParcelableAdapter implements ParcelableAdapter<Short> {
 
     private final Short value;
 
-    public ShortParcelableAdapter(Short value) {
-        this.value = value;
-    }
-
     public static final Creator<ShortParcelableAdapter> CREATOR =
             new Creator<ShortParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class ShortParcelableAdapter implements ParcelableAdapter<Short> {
                     return new ShortParcelableAdapter[size];
                 }
             };
+
+    public ShortParcelableAdapter(Short value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/adapter/StringParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/StringParcelableAdapter.java
@@ -17,10 +17,6 @@ public class StringParcelableAdapter implements ParcelableAdapter<String> {
 
     private final String value;
 
-    public StringParcelableAdapter(String value) {
-        this.value = value;
-    }
-
     public static final Creator<StringParcelableAdapter> CREATOR =
             new Creator<StringParcelableAdapter>() {
 
@@ -35,6 +31,10 @@ public class StringParcelableAdapter implements ParcelableAdapter<String> {
                     return new StringParcelableAdapter[size];
                 }
             };
+
+    public StringParcelableAdapter(String value) {
+        this.value = value;
+    }
 
     @Override
     public int describeContents() {

--- a/postman/src/main/java/com/workday/postman/parceler/ArrayListBundler.java
+++ b/postman/src/main/java/com/workday/postman/parceler/ArrayListBundler.java
@@ -20,9 +20,6 @@ import java.util.ArrayList;
  */
 class ArrayListBundler {
 
-    private ArrayListBundler() {
-    }
-
     private static final InnerListBundler<Integer> INTEGER_LIST_BUNDLER
             = new InnerListBundler<Integer>() {
 
@@ -103,6 +100,9 @@ class ArrayListBundler {
                     return unwrapped;
                 }
             };
+
+    private ArrayListBundler() {
+    }
 
     public static <T> void writeArrayListToBundle(ArrayList<T> list, Bundle bundle,
                                                   Class<T> itemClass, String key) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
