### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/postman-processor/src/main/java/com/workday/postman/codegen/ParceledElementExtractor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/ParceledElementExtractor.java
@@ -122,7 +122,7 @@ class ParceledElementExtractor {
     }
 
     private Collection<VariableElement> extractValidFields(Collection<VariableElement> allFields) {
-        Collection<VariableElement> validFields = new ArrayList<VariableElement>(allFields.size());
+        Collection<VariableElement> validFields = new ArrayList<>(allFields.size());
         for (VariableElement field : allFields) {
             boolean shouldAdd = true;
 
@@ -162,7 +162,7 @@ class ParceledElementExtractor {
     private Collection<VariableElement> extractAnnotatedFields(Collection<VariableElement>
                                                                        allFields) {
         Collection<VariableElement> validAnnotatedFields =
-                new ArrayList<VariableElement>(allFields.size());
+                new ArrayList<>(allFields.size());
 
         for (VariableElement field : allFields) {
             boolean shouldAdd = hasParceledAnnotation(field);

--- a/postman-processor/src/main/java/com/workday/postman/codegen/ParcelerGenerator.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/ParcelerGenerator.java
@@ -91,7 +91,7 @@ class ParcelerGenerator {
     }
 
     private Set<String> getImports() {
-        Set<String> imports = new HashSet<String>();
+        Set<String> imports = new HashSet<>();
         imports.add("android.os.Bundle");
         imports.add("android.os.Parcel");
         imports.add(Parceler.class.getCanonicalName());
@@ -99,7 +99,7 @@ class ParcelerGenerator {
     }
 
     private void writeWriteToParcelMethod(JavaWriter writer) throws IOException {
-        List<String> parameters = new ArrayList<String>(4);
+        List<String> parameters = new ArrayList<>(4);
         parameters.add(elementCompressedName);
         parameters.add("object");
         parameters.add("Parcel");

--- a/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
@@ -35,7 +35,7 @@ import javax.tools.Diagnostic;
  */
 public class PostmanProcessor extends AbstractProcessor {
 
-    private Set<TypeElement> handledElements = new HashSet<TypeElement>();
+    private Set<TypeElement> handledElements = new HashSet<>();
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/postman/src/main/java/com/workday/postman/adapter/AbstractMapParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/AbstractMapParcelableAdapter.java
@@ -57,8 +57,8 @@ public class AbstractMapParcelableAdapter<T extends Map> implements ParcelableAd
             final Map<Object, Object> castedMap = (Map<Object, Object>) map;
             for (int i = 0; i < keys.length; i++) {
                 final Object key = ParcelableAdapters.unwrapParcelable(keys[i]);
-                final Object value = ParcelableAdapters.unwrapParcelable(values[i]);
-                castedMap.put(key, value);
+                final Object val = ParcelableAdapters.unwrapParcelable(values[i]);
+                castedMap.put(key, val);
             }
             return newParcelableAdapterInstance(map);
         }

--- a/postman/src/main/java/com/workday/postman/adapter/CharSequenceParcelableAdapter.java
+++ b/postman/src/main/java/com/workday/postman/adapter/CharSequenceParcelableAdapter.java
@@ -28,9 +28,9 @@ public class CharSequenceParcelableAdapter implements ParcelableAdapter<CharSequ
 
                 @Override
                 public CharSequenceParcelableAdapter createFromParcel(Parcel source) {
-                    final CharSequence value =
+                    final CharSequence val =
                             TextUtils.CHAR_SEQUENCE_CREATOR.createFromParcel(source);
-                    return new CharSequenceParcelableAdapter(value);
+                    return new CharSequenceParcelableAdapter(val);
                 }
 
                 @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2293 - The diamond operator ("<>") should be used. 
squid:HiddenFieldCheck - Local variables should not shadow class fields. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.

Faisal Hameed
