### PR TITLE
Add compilation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ android:
     - android-23
     - build-tools-23.0.1
 
-script: ./gradlew assemble check
+script: ./gradlew build

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
-Copyright 2015 Workday, Inc.
+Copyright 2015-2016 Workday, Inc.
+Copyright 2016 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the

--- a/postman-processor/build.gradle
+++ b/postman-processor/build.gradle
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2015 Workday, Inc.
+ * Copyright 2016 Google, Inc.
+ *
+ * This software is available under the MIT license.
+ * Please see the LICENSE.txt file in this project.
+ */
+
 apply plugin: 'java'
 apply from: file('../gradle/checkstyle.gradle')
 apply from: file('../gradle/gradle-mvn-push.gradle')

--- a/postman-processor/build.gradle
+++ b/postman-processor/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     compile project(':postman')
     compile 'com.squareup:javawriter:2.5.1'
     compile 'com.workday:metajava:1.0'
+
+    testCompile 'com.google.testing.compile:compile-testing:0.9'
+    testCompile 'com.google.android:android:2.3.1'
 }

--- a/postman-processor/src/main/java/com/workday/postman/codegen/ParceledElementExtractor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/ParceledElementExtractor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Workday, Inc.
+ * Copyright 2016 Google, Inc.
  *
  * This software is available under the MIT license.
  * Please see the LICENSE.txt file in this project.

--- a/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
@@ -14,6 +14,7 @@ import com.workday.postman.parceler.Parceler;
 import com.workday.postman.util.CollectionUtils;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -36,7 +37,6 @@ import javax.tools.Diagnostic;
  */
 public class PostmanProcessor extends AbstractProcessor {
 
-    private Set<TypeElement> handledElements = new HashSet<>();
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
@@ -44,6 +44,8 @@ public class PostmanProcessor extends AbstractProcessor {
         if (annotations == null || annotations.isEmpty()) {
             return false;
         }
+
+        final Set<TypeElement> handledElements = new HashSet<>();
 
         Set<? extends Element> annotatedElements =
                 roundEnv.getElementsAnnotatedWith(Parceled.class);
@@ -57,21 +59,8 @@ public class PostmanProcessor extends AbstractProcessor {
             }
         }
 
-        Set<? extends Element> postCreateChildElements =
-                roundEnv.getElementsAnnotatedWith(PostCreateChild.class);
-        for (Element e : postCreateChildElements) {
-            TypeElement parent = (TypeElement) e.getEnclosingElement();
-            if (!handledElements.contains(parent)) {
-                final String message = String.format(Locale.US,
-                                                     "You marked a method with @%s in a class "
-                                                             + "that has no @%s annotations. The "
-                                                             + "enclosing class will not be "
-                                                             + "parceled.",
-                                                     PostCreateChild.class.getSimpleName(),
-                                                     Parceled.class.getSimpleName());
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, e);
-            }
-        }
+        checkIfParentsParceled(roundEnv, handledElements, NotParceled.class);
+        checkIfParentsParceled(roundEnv, handledElements, PostCreateChild.class);
 
         for (TypeElement handledElement : handledElements) {
             ParcelerGenerator generator = new ParcelerGenerator(processingEnv, handledElement);
@@ -84,6 +73,26 @@ public class PostmanProcessor extends AbstractProcessor {
         }
 
         return true;
+    }
+
+    private void checkIfParentsParceled(RoundEnvironment roundEnv,
+                                        Set<TypeElement> handledElements,
+                                        Class<? extends Annotation> annotationType) {
+        Set<? extends Element> annotatedElements =
+                roundEnv.getElementsAnnotatedWith(annotationType);
+        for (Element e : annotatedElements) {
+            TypeElement parent = (TypeElement) e.getEnclosingElement();
+            if (!handledElements.contains(parent)) {
+                final String message = String.format(Locale.US,
+                                                     "You marked an element with @%s in a class "
+                                                             + "that has no @%s annotations. The "
+                                                             + "enclosing class will not be "
+                                                             + "parceled.",
+                                                     annotationType.getSimpleName(),
+                                                     Parceled.class.getSimpleName());
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, e);
+            }
+        }
     }
 
     @Override

--- a/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Workday, Inc.
+ * Copyright 2016 Google, Inc.
  *
  * This software is available under the MIT license.
  * Please see the LICENSE.txt file in this project.

--- a/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
+++ b/postman-processor/src/main/java/com/workday/postman/codegen/PostmanProcessor.java
@@ -15,6 +15,7 @@ import com.workday.postman.util.CollectionUtils;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -53,6 +54,22 @@ public class PostmanProcessor extends AbstractProcessor {
                 handledElements.add(parent);
             } else if (kind == ElementKind.CLASS) {
                 handledElements.add((TypeElement) e);
+            }
+        }
+
+        Set<? extends Element> postCreateChildElements =
+                roundEnv.getElementsAnnotatedWith(PostCreateChild.class);
+        for (Element e : postCreateChildElements) {
+            TypeElement parent = (TypeElement) e.getEnclosingElement();
+            if (!handledElements.contains(parent)) {
+                final String message = String.format(Locale.US,
+                                                     "You marked a method with @%s in a class "
+                                                             + "that has no @%s annotations. The "
+                                                             + "enclosing class will not be "
+                                                             + "parceled.",
+                                                     PostCreateChild.class.getSimpleName(),
+                                                     Parceled.class.getSimpleName());
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, e);
             }
         }
 

--- a/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
+++ b/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2016 Workday, Inc.
+ *
+ * This software is available under the MIT license.
+ * Please see the LICENSE.txt file in this project.
+ */
+
+package com.workday.postman.codegen;
+
+import com.google.testing.compile.JavaFileObjects;
+import com.workday.postman.util.Names;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+/**
+ * @author ndtaylor
+ * @since 2016-07-10.
+ */
+@RunWith(JUnit4.class)
+public class PostmanProcessorTest {
+
+    @Test
+    public void testEmptyAnnotatedClass() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;"
+                + "import com.workday.postman.annotations.Parceled;"
+                + ""
+                + " @Parceled"
+                + " public class TestClass { }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .and()
+                                 .generatesFileNamed(StandardLocation.SOURCE_OUTPUT,
+                                                     "test",
+                                                     getParcelerFileName("TestClass"));
+    }
+
+    @Test
+    public void testPrivateAnnotatedFieldRaisesCompilationError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @Parceled\n"
+                + "   private String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining("Cannot access private fields when "
+                                                              + "parceling.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testFinalAnnotatedFieldRaisesCompilationError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @Parceled\n"
+                + "   final String myString = \"The final word.\";\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining("Cannot access final fields when parceling.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testStaticAnnotatedFieldRaisesWarning() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @Parceled\n"
+                + "   static String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "You marked static field myString as parceled")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testStaticFieldInAnnotatedClassRaisesWarning() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   static String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "Static field myString will be parceled, but you "
+                                                 + "probably don't want it to be. You can mark "
+                                                 + "this field as not parceled with @NotParceled.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testNotParceledlAnnotatedFieldRaisesWarning() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.NotParceled;import com.workday.postman"
+                + ".annotations.Parceled;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @NotParceled\n"
+                + "   String myString;\n"
+                + "   @Parceled\n"
+                + "   String myParceledString;"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "@NotParceled annotations are ignored when the enclosing "
+                                                 + "class is not annotated with @Parceled.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    // TODO: 2016-07-10 Implement this functionality
+    @Ignore
+    @Test
+    public void testNotParceledlAnnotatedFieldRaisesErrorInNonParceledClass() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.NotParceled;import com.workday.postman"
+                + ".annotations.Parceled;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @NotParceled\n"
+                + "   String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "You marked a field as @NotParceled in a class that has "
+                                                 + "no @Parceled annotations. The enclosing "
+                                                 + "class will not be parceled.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testPrivateFieldRaisesWarning() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   private String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "Parceler will ignore private field myString.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testFinalFieldRaisesWarning() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   final String myString = \"The final word.\";\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "Parceler will ignore final field myString.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testParceledAnnotatedFieldRaisesWarningInAnnotatedClass() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @Parceled\n"
+                + "   String myString;\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .compilesWithoutError()
+                                 .withWarningContaining(
+                                         "@Parceled annotations are ignored on fields when the "
+                                                 + "enclosing class is annotated with @Parceled.")
+                                 .in(source)
+                                 .onLine(7);
+    }
+
+    @Test
+    public void testPrivatePostCreateChildRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   private void onPostCreateChild(Object o) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild cannot be "
+                                                 + "private.")
+                                 .in(source)
+                                 .onLine(8);
+    }
+
+    @Test
+    public void testStaticPostCreateChildRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   static void onPostCreateChild(Object o) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild cannot be "
+                                                 + "static.")
+                                 .in(source)
+                                 .onLine(8);
+    }
+
+    @Test
+    public void testPostCreateChildWithNoArgumentRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   void onPostCreateChild() { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild must take a "
+                                                 + "single argument of type Object.")
+                                 .in(source)
+                                 .onLine(8);
+    }
+
+    @Test
+    public void testPostCreateChildWithWrongArgumentTypeRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   void onPostCreateChild(String s) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild must take a "
+                                                 + "single argument of type Object.")
+                                 .in(source)
+                                 .onLine(8);
+    }
+
+    @Test
+    public void testPostCreateChildWithTooMayArgumentsRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " @Parceled\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   void onPostCreateChild(Object o1, Object o2) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild must take a "
+                                                 + "single argument of type Object.")
+                                 .in(source)
+                                 .onLine(8);
+    }
+
+    // TODO: 2016-07-10 Implement this functionality
+    @Ignore
+    @Test
+    public void testPostCreateInClassWithNoParceledAnnotationsRaisesError() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @PostCreateChild\n"
+                + "   void onPostCreateChild(Object o1) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorContaining(
+                                         "You marked a method with @PostCreateChild in a class "
+                                                 + "that has no @Parceled annotations. The "
+                                                 + "enclosing class will not be parceled.")
+                                 .in(source)
+                                 .onLine(6);
+    }
+
+    @Test
+    public void testMultipleErrorsAndWarnings() throws Exception {
+        //language=JAVA
+        final String sourceString = "package test;\n"
+                + "import com.workday.postman.annotations.NotParceled;\n"
+                + "import com.workday.postman.annotations.Parceled;\n"
+                + "import com.workday.postman.annotations.PostCreateChild;\n"
+                + "\n"
+                + " public class TestClass {\n"
+                + "   @Parceled\n"
+                + "   final String myFinal = \"The final word.\";\n"
+                + "   @NotParceled\n"
+                + "   String myNotParceled;\n"
+                + "   @Parceled\n"
+                + "   private String myPrivate;\n"
+                + "   @Parceled\n"
+                + "   static String myStatic;\n"
+                + "   @PostCreateChild\n"
+                + "   private void onPostCreateChild(Object o) { }\n"
+                + " }";
+        JavaFileObject source = JavaFileObjects.forSourceString("test.TestClass", sourceString);
+        assertAbout(javaSource()).that(source)
+                                 .processedWith(new PostmanProcessor())
+                                 .failsToCompile()
+                                 .withErrorCount(3)
+                                 .withErrorContaining("Cannot access final field")
+                                 .and()
+                                 .withErrorContaining("Cannot access private field")
+                                 .and()
+                                 .withErrorContaining(
+                                         "Methods annotated with @PostCreateChild cannot be "
+                                                 + "private")
+                                 .and()
+                                 .withWarningCount(2)
+                                 .withWarningContaining(
+                                         "You marked static field myStatic as parceled")
+                                 .and()
+                                 .withWarningContaining("NotParceled annotations are ignored");
+
+    }
+
+    private String getParcelerFileName(String className) {
+        return className + Names.PARCELER_SUFFIX + ".java";
+    }
+}

--- a/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
+++ b/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
@@ -10,7 +10,6 @@ package com.workday.postman.codegen;
 import com.google.testing.compile.JavaFileObjects;
 import com.workday.postman.util.Names;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -151,8 +150,6 @@ public class PostmanProcessorTest {
                                  .onLine(6);
     }
 
-    // TODO: 2016-07-10 Implement this functionality
-    @Ignore
     @Test
     public void testNotParceledlAnnotatedFieldRaisesErrorInNonParceledClass() throws Exception {
         //language=JAVA
@@ -169,8 +166,8 @@ public class PostmanProcessorTest {
                                  .processedWith(new PostmanProcessor())
                                  .failsToCompile()
                                  .withErrorContaining(
-                                         "You marked a field as @NotParceled in a class that has "
-                                                 + "no @Parceled annotations. The enclosing "
+                                         "You marked an element with @NotParceled in a class that "
+                                                 + "has no @Parceled annotations. The enclosing "
                                                  + "class will not be parceled.")
                                  .in(source)
                                  .onLine(6);
@@ -368,7 +365,7 @@ public class PostmanProcessorTest {
                                  .processedWith(new PostmanProcessor())
                                  .failsToCompile()
                                  .withErrorContaining(
-                                         "You marked a method with @PostCreateChild in a class "
+                                         "You marked an element with @PostCreateChild in a class "
                                                  + "that has no @Parceled annotations. The "
                                                  + "enclosing class will not be parceled.")
                                  .in(source)

--- a/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
+++ b/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
@@ -353,8 +353,6 @@ public class PostmanProcessorTest {
                                  .onLine(8);
     }
 
-    // TODO: 2016-07-10 Implement this functionality
-    @Ignore
     @Test
     public void testPostCreateInClassWithNoParceledAnnotationsRaisesError() throws Exception {
         //language=JAVA

--- a/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
+++ b/postman-processor/src/test/java/com/workday/postman/codegen/PostmanProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Workday, Inc.
+ * Copyright 2016 Google, Inc.
  *
  * This software is available under the MIT license.
  * Please see the LICENSE.txt file in this project.


### PR DESCRIPTION
This change also raises new compilation errors when applying `@NotParceled` and `@PostCreateChild` to classes that will not be parceled.
